### PR TITLE
Enable concurrent request handling

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,6 @@
 use capnp::capability::Promise;
+use std::sync::Arc;
+use tokio::task;
 
 use crate::{
     protocol::queue::{
@@ -10,40 +12,91 @@ use crate::{
 // https://github.com/capnproto/capnproto-rust/tree/master/capnp-rpc
 // https://github.com/capnproto/capnproto-rust/blob/master/capnp-rpc/examples/hello-world/server.rs
 pub struct Server {
-    storage: Storage,
+    storage: Arc<Storage>,
 }
 
 impl Server {
     pub fn new(storage: Storage) -> Self {
-        Self { storage }
+        Self {
+            storage: Arc::new(storage),
+        }
     }
 }
 
 impl crate::protocol::queue::Server for Server {
     fn add(&mut self, params: AddParams, mut results: AddResults) -> Promise<(), capnp::Error> {
-        let req = params.get()?.get_req()?;
-        // let contents = req.get_contents()?;
-        // let visibility_timeout_secs = req.get_visibility_timeout_secs();
+        // Extract everything we need from non-Send capnp params on this thread.
+        let req = match params.get() {
+            Ok(p) => p.get_req(),
+            Err(e) => return Promise::err(e),
+        };
+        let req = match req {
+            Ok(r) => r,
+            Err(e) => return Promise::err(e),
+        };
 
-        let items = req.get_items()?;
+        let items = match req.get_items() {
+            Ok(i) => i,
+            Err(e) => return Promise::err(e),
+        };
 
-        let ids = items
-            .iter()
-            .map(|_| uuid::Uuid::now_v7().as_bytes().to_vec())
-            .collect::<Vec<_>>();
-
-        // TODO: do we need to run this in an io thread pool or smth?
-        self.storage
-            .add_available_items(ids.iter().map(AsRef::as_ref).zip(items.iter()))
-            .map_err(|e| capnp::Error::failed(e.to_string()))?;
-
-        // build the response
-        let mut ids_builder = results.get().init_resp().init_ids(ids.len() as u32);
-        for (i, id) in ids.iter().enumerate() {
-            ids_builder.set(i as u32, id);
+        // Generate IDs here (still on this thread) and copy item data we need to move to a blocking thread.
+        let mut ids: Vec<Vec<u8>> = Vec::with_capacity(items.len() as usize);
+        let mut owned_items: Vec<(Vec<u8>, u64)> = Vec::with_capacity(items.len() as usize);
+        for it in items.iter() {
+            ids.push(uuid::Uuid::now_v7().as_bytes().to_vec());
+            // Copy out contents and visibility timeout so we can move work off-thread safely.
+            let contents = match it.get_contents() {
+                Ok(c) => c.to_vec(),
+                Err(e) => return Promise::err(e),
+            };
+            let visibility = it.get_visibility_timeout_secs();
+            owned_items.push((contents, visibility));
         }
 
-        Promise::ok(())
+        let storage = Arc::clone(&self.storage);
+        // Clone ids for the blocking thread so we can still use the originals to build the response.
+        let ids_for_storage = ids.clone();
+
+        // Perform the blocking RocksDB writes on a dedicated blocking thread, and await here without blocking the local reactor.
+        Promise::from_future(async move {
+            // Move data for storage: pair each generated id with a capnp item we rebuild locally per entry.
+            let storage_task = task::spawn_blocking(move || -> Result<(), crate::errors::Error> {
+                for (id, (contents, visibility)) in ids_for_storage
+                    .iter()
+                    .map(AsRef::as_ref)
+                    .zip(owned_items)
+                {
+                    // Rebuild a protocol::item from owned data for the storage API.
+                    let mut msg = capnp::message::Builder::new_default();
+                    {
+                        let mut item = msg.init_root::<crate::protocol::item::Builder>();
+                        item.set_contents(&contents);
+                        item.set_visibility_timeout_secs(visibility);
+                    }
+                    let item_reader = msg.into_typed().into_reader();
+                    storage.add_available_item((id, item_reader.get()?))?;
+                }
+                Ok(())
+            });
+
+            // Propagate any blocking-thread error back into capnp error space.
+            match storage_task.await {
+                Ok(Ok(())) => {
+                    // Build the response (must be done on this thread, results is !Send).
+                    let mut ids_builder = results.get().init_resp().init_ids(ids.len() as u32);
+                    for (i, id) in ids.iter().enumerate() {
+                        ids_builder.set(i as u32, id);
+                    }
+                    Ok(())
+                }
+                Ok(Err(e)) => Err(capnp::Error::failed(e.to_string())),
+                Err(join_err) => Err(capnp::Error::failed(format!(
+                    "spawn_blocking join error: {}",
+                    join_err
+                ))),
+            }
+        })
     }
 
     fn remove(&mut self, _: RemoveParams, _: RemoveResults) -> Promise<(), capnp::Error> {


### PR DESCRIPTION
Enable concurrent request handling in the server by offloading blocking storage operations to a thread pool and making `Storage` safe for concurrent access.

---
<a href="https://cursor.com/background-agent?bcId=bc-b2e2bcc7-0109-499f-b3cb-1cecc3e05d8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b2e2bcc7-0109-499f-b3cb-1cecc3e05d8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

