### PR TITLE
Implement automatic error mapping in errors.rs

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -39,3 +39,10 @@ pub enum Error {
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+impl From<Error> for capnp::Error {
+    fn from(err: Error) -> Self {
+        // Convert any internal error to a failed Cap'n Proto RPC error.
+        capnp::Error::failed(err.to_string())
+    }
+}


### PR DESCRIPTION
Implement `From<Error> for capnp::Error` to simplify error handling in RPC methods.

---
<a href="https://cursor.com/background-agent?bcId=bc-cda0fed7-6476-423c-bea5-bb232a7f605c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cda0fed7-6476-423c-bea5-bb232a7f605c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

