### PR TITLE
Fix the bug

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -53,4 +53,3 @@ impl From<Error> for capnp::Error {
         capnp::Error::failed(err.to_string())
     }
 }
-

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,195 +2,212 @@ use capnp::capability::Promise;
 use capnp::message::{Builder, HeapAllocator, TypedReader};
 use std::sync::Arc;
 use tokio::sync::Notify;
-use tokio::time::Duration;
 use tokio::sync::watch;
+use tokio::time::Duration;
 
 use crate::errors::{Error, Result};
 use crate::{
-	protocol::queue::{
-		AddParams, AddResults, PollParams, PollResults, RemoveParams, RemoveResults,
-	},
-	storage::Storage,
+    protocol::queue::{
+        AddParams, AddResults, PollParams, PollResults, RemoveParams, RemoveResults,
+    },
+    storage::Storage,
 };
 
 // https://github.com/capnproto/capnproto-rust/tree/master/capnp-rpc
 // https://github.com/capnproto/capnproto-rust/blob/master/capnp-rpc/examples/hello-world/server.rs
 pub struct Server {
-	storage: Arc<Storage>,
-	notify: Arc<Notify>,
-	#[allow(dead_code)]
-	shutdown_tx: watch::Sender<bool>,
+    storage: Arc<Storage>,
+    notify: Arc<Notify>,
+    #[allow(dead_code)]
+    shutdown_tx: watch::Sender<bool>,
 }
 
 impl Server {
-	pub fn new(storage: Arc<Storage>, notify: Arc<Notify>, shutdown_tx: watch::Sender<bool>) -> Self {
-		let bg_storage = Arc::clone(&storage);
-		let bg_notify = Arc::clone(&notify);
-		let bg_shutdown_tx = shutdown_tx.clone();
+    pub fn new(
+        storage: Arc<Storage>,
+        notify: Arc<Notify>,
+        shutdown_tx: watch::Sender<bool>,
+    ) -> Self {
+        let bg_storage = Arc::clone(&storage);
+        let bg_notify = Arc::clone(&notify);
+        let bg_shutdown_tx = shutdown_tx.clone();
 
-		// Background task to expire leases periodically
-		tokio::spawn(async move {
-			loop {
-				let st = Arc::clone(&bg_storage);
-				match tokio::task::spawn_blocking(move || st.expire_due_leases()).await {
-					Ok(Ok(n)) => {
-						if n > 0 {
-							bg_notify.notify_waiters();
-						}
-					}
-					Ok(Err(_e)) => {
-						let _ = bg_shutdown_tx.send(true);
-						break;
-					}
-					Err(_join_err) => {
-						let _ = bg_shutdown_tx.send(true);
-						break;
-					}
-				}
-				tokio::time::sleep(Duration::from_millis(500)).await;
-			}
-		});
+        // Background task to expire leases periodically
+        tokio::spawn(async move {
+            loop {
+                let st = Arc::clone(&bg_storage);
+                match tokio::task::spawn_blocking(move || st.expire_due_leases()).await {
+                    Ok(Ok(n)) => {
+                        if n > 0 {
+                            bg_notify.notify_waiters();
+                        }
+                    }
+                    Ok(Err(_e)) => {
+                        let _ = bg_shutdown_tx.send(true);
+                        break;
+                    }
+                    Err(_join_err) => {
+                        let _ = bg_shutdown_tx.send(true);
+                        break;
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+        });
 
-		Self { storage, notify, shutdown_tx }
-	}
+        Self {
+            storage,
+            notify,
+            shutdown_tx,
+        }
+    }
 }
 
 impl crate::protocol::queue::Server for Server {
-	fn add(&mut self, params: AddParams, mut results: AddResults) -> Promise<(), capnp::Error> {
-		let req = params.get()?;
-		let req = req.get_req()?;
-		let items = req.get_items()?;
+    fn add(&mut self, params: AddParams, mut results: AddResults) -> Promise<(), capnp::Error> {
+        let req = params.get()?;
+        let req = req.get_req()?;
+        let items = req.get_items()?;
 
-		// Generate ids upfront and copy request data into owned memory so we can move
-		// it into a blocking task (capnp readers are not Send).
-		let ids: Vec<Vec<u8>> = items
-			.iter()
-			.map(|_| uuid::Uuid::now_v7().as_bytes().to_vec())
-			.collect();
+        // Generate ids upfront and copy request data into owned memory so we can move
+        // it into a blocking task (capnp readers are not Send).
+        let ids: Vec<Vec<u8>> = items
+            .iter()
+            .map(|_| uuid::Uuid::now_v7().as_bytes().to_vec())
+            .collect();
 
-		let items_owned = items
-			.iter()
-			.map(|item| -> Result<_> {
-				let contents = item.get_contents()?.to_vec();
-				let vis = item.get_visibility_timeout_secs();
-				Ok((contents, vis))
-			})
-			.collect::<Result<Vec<_>>>()
-			.map_err(Into::<capnp::Error>::into)?;
+        let items_owned = items
+            .iter()
+            .map(|item| -> Result<_> {
+                let contents = item.get_contents()?.to_vec();
+                let vis = item.get_visibility_timeout_secs();
+                Ok((contents, vis))
+            })
+            .collect::<Result<Vec<_>>>()
+            .map_err(Into::<capnp::Error>::into)?;
 
-		let storage = Arc::clone(&self.storage);
-		let notify = Arc::clone(&self.notify);
-		let ids_for_resp = ids.clone();
+        let storage = Arc::clone(&self.storage);
+        let notify = Arc::clone(&self.notify);
+        let ids_for_resp = ids.clone();
 
-		Promise::from_future(async move {
-			// Offload RocksDB work to the blocking thread pool.
-			tokio::task::spawn_blocking(move || {
-				let iter = ids
-					.iter()
-					.map(|id| id.as_slice())
-					.zip(items_owned.iter().map(|(c, v)| (c.as_slice(), *v)));
-				storage.add_available_items_from_parts(iter)
-			})
-			.await
-			.map_err(Into::<Error>::into)??;
+        Promise::from_future(async move {
+            // Offload RocksDB work to the blocking thread pool.
+            tokio::task::spawn_blocking(move || {
+                let iter = ids
+                    .iter()
+                    .map(|id| id.as_slice())
+                    .zip(items_owned.iter().map(|(c, v)| (c.as_slice(), *v)));
+                storage.add_available_items_from_parts(iter)
+            })
+            .await
+            .map_err(Into::<Error>::into)??;
 
-			// Notify any waiters that new items may be available
-			notify.notify_waiters();
+            // Notify any waiters that new items may be available
+            notify.notify_waiters();
 
-			// Build the response on the RPC thread.
-			let mut ids_builder = results
-				.get()
-				.init_resp()
-				.init_ids(ids_for_resp.len() as u32);
-			for (i, id) in ids_for_resp.iter().enumerate() {
-				ids_builder.set(i as u32, id);
-			}
-			Ok(())
-		})
-	}
+            // Build the response on the RPC thread.
+            let mut ids_builder = results
+                .get()
+                .init_resp()
+                .init_ids(ids_for_resp.len() as u32);
+            for (i, id) in ids_for_resp.iter().enumerate() {
+                ids_builder.set(i as u32, id);
+            }
+            Ok(())
+        })
+    }
 
-	fn remove(
-		&mut self,
-		params: RemoveParams,
-		mut results: RemoveResults,
-	) -> Promise<(), capnp::Error> {
-		let req = params.get()?.get_req()?;
-		let id = req.get_id()?;
-		let lease_bytes = req.get_lease()?;
+    fn remove(
+        &mut self,
+        params: RemoveParams,
+        mut results: RemoveResults,
+    ) -> Promise<(), capnp::Error> {
+        let req = params.get()?.get_req()?;
+        let id = req.get_id()?;
+        let lease_bytes = req.get_lease()?;
 
-		if lease_bytes.len() != 16 {
-			return Promise::err(capnp::Error::failed("invalid lease length".to_string()));
-		}
-		let mut lease: [u8; 16] = [0; 16];
-		lease.copy_from_slice(lease_bytes);
+        if lease_bytes.len() != 16 {
+            return Promise::err(capnp::Error::failed("invalid lease length".to_string()));
+        }
+        let mut lease: [u8; 16] = [0; 16];
+        lease.copy_from_slice(lease_bytes);
 
-		let removed = self
-			.storage
-			.remove_in_progress_item(id, &lease)
-			.map_err(Into::into)?;
+        let removed = self
+            .storage
+            .remove_in_progress_item(id, &lease)
+            .map_err(Into::into)?;
 
-		results.get().init_resp().set_removed(removed);
-		Promise::ok(())
-	}
+        results.get().init_resp().set_removed(removed);
+        Promise::ok(())
+    }
 
-	fn poll(&mut self, params: PollParams, mut results: PollResults) -> Promise<(), capnp::Error> {
-		let storage = Arc::clone(&self.storage);
-		let notify = Arc::clone(&self.notify);
+    fn poll(&mut self, params: PollParams, mut results: PollResults) -> Promise<(), capnp::Error> {
+        let storage = Arc::clone(&self.storage);
+        let notify = Arc::clone(&self.notify);
 
-		Promise::from_future(async move {
-			let req = params.get()?.get_req()?;
-			let lease_validity_secs = req.get_lease_validity_secs();
-			if lease_validity_secs == 0 {
-				return Err(capnp::Error::failed("invariant: leaseValiditySecs must be > 0".to_string()));
-			}
-			let num_items = match req.get_num_items() {
-				0 => 1,
-				n => n as usize,
-			};
-			let timeout_secs = req.get_timeout_secs();
+        Promise::from_future(async move {
+            let req = params.get()?.get_req()?;
+            let lease_validity_secs = req.get_lease_validity_secs();
+            if lease_validity_secs == 0 {
+                return Err(capnp::Error::failed(
+                    "invariant: leaseValiditySecs must be > 0".to_string(),
+                ));
+            }
+            let num_items = match req.get_num_items() {
+                0 => 1,
+                n => n as usize,
+            };
+            let timeout_secs = req.get_timeout_secs();
 
-			let (lease, items) =
-				storage.get_next_available_entries_with_lease(num_items, lease_validity_secs)?;
-			if !items.is_empty() {
-				write_poll_response(&lease, items, &mut results)?;
-				return Ok(());
-			}
+            let deadline = if timeout_secs > 0 {
+                Some(std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs))
+            } else {
+                None
+            };
 
-			// Wait to be notified of new data for timeout_secs (0 means wait indefinitely)
-			if timeout_secs > 0 {
-				let timeout = tokio::time::sleep(std::time::Duration::from_secs(timeout_secs));
-				tokio::select! {
-					_ = notify.notified() => {},
-					_ = timeout => {},
-				}
-			} else {
-				notify.notified().await;
-			}
+            loop {
+                let (lease, items) = storage
+                    .get_next_available_entries_with_lease(num_items, lease_validity_secs)?;
+                if !items.is_empty() {
+                    write_poll_response(&lease, items, &mut results)?;
+                    return Ok(());
+                }
 
-			let (lease, items) =
-				storage.get_next_available_entries_with_lease(num_items, lease_validity_secs)?;
-			if !items.is_empty() {
-				write_poll_response(&lease, items, &mut results)?;
-			}
-			Ok(())
-		})
-	}
+                match deadline {
+                    Some(d) => {
+                        let now = std::time::Instant::now();
+                        if now >= d {
+                            return Ok(());
+                        }
+                        let remaining = d - now;
+                        tokio::select! {
+                            _ = notify.notified() => {},
+                            _ = tokio::time::sleep(remaining) => { return Ok(()); },
+                        }
+                    }
+                    None => {
+                        notify.notified().await;
+                    }
+                }
+            }
+        })
+    }
 }
 
 fn write_poll_response(
-	lease: &[u8; 16],
-	items: Vec<TypedReader<Builder<HeapAllocator>, crate::protocol::polled_item::Owned>>,
-	results: &mut crate::protocol::queue::PollResults,
+    lease: &[u8; 16],
+    items: Vec<TypedReader<Builder<HeapAllocator>, crate::protocol::polled_item::Owned>>,
+    results: &mut crate::protocol::queue::PollResults,
 ) -> Result<()> {
-	let mut resp = results.get().init_resp();
-	resp.set_lease(lease);
+    let mut resp = results.get().init_resp();
+    resp.set_lease(lease);
 
-	let mut items_builder = resp.init_items(items.len() as u32);
-	for (i, typed_polled_item) in items.into_iter().enumerate() {
-		let item_reader = typed_polled_item.get()?;
-		let mut out_item = items_builder.reborrow().get(i as u32);
-		out_item.set_contents(item_reader.get_contents()?);
-		out_item.set_id(item_reader.get_id()?);
-	}
-	Ok(())
+    let mut items_builder = resp.init_items(items.len() as u32);
+    for (i, typed_polled_item) in items.into_iter().enumerate() {
+        let item_reader = typed_polled_item.get()?;
+        let mut out_item = items_builder.reborrow().get(i as u32);
+        out_item.set_contents(item_reader.get_contents()?);
+        out_item.set_id(item_reader.get_id()?);
+    }
+    Ok(())
 }


### PR DESCRIPTION
Refactor `poll` to wait until items are visible or timeout expires, fixing early returns on non-visible item notifications.

Previously, the `poll` method would return immediately upon receiving any notification, even if the newly added item was not yet visible (e.g., due to a future `visibility_timeout_secs`). This led to clients receiving empty responses prematurely. The updated logic ensures `poll` continues to wait until truly available items are found or the specified timeout is reached.

---
<a href="https://cursor.com/background-agent?bcId=bc-c10f7ad4-851a-4ac6-925d-aed1327fad00">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c10f7ad4-851a-4ac6-925d-aed1327fad00">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

