### PR TITLE
Fix benchmark hanging with server poll

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -15,5 +15,5 @@
 - [ ] (major) fix race condition: concurrent polls can hand out the same messages
 - [X] (feat) implement remove
 - [ ] (feat) implement extend
-- [ ] (bugfix) e2e benchmark hangs / improve benchmarks
+- [X] (bugfix) e2e benchmark hangs / improve benchmarks
 - [X] (bugfix) polling returns early if it's woken by a new message being added, *even if it isnt visible*.


### PR DESCRIPTION
Refactor e2e benchmarks to use async client driving to prevent hanging.

---
<a href="https://cursor.com/background-agent?bcId=bc-f8ff558b-ef0e-4db5-a9a0-5eed3404c7e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f8ff558b-ef0e-4db5-a9a0-5eed3404c7e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

