### PR TITLE
Implement wakeup performance improvements

### DIFF
--- a/benches/storage_bench.rs
+++ b/benches/storage_bench.rs
@@ -168,8 +168,8 @@ fn ensure_server_started() -> &'static ServerHandle {
                 let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
                 let storage = Arc::new(Storage::new(&data_path).unwrap());
                 let (shutdown_tx, _rx) = tokio::sync::watch::channel(false);
-                let notify = Arc::new(tokio::sync::Notify::new());
-                let server = Server::new(storage, notify, shutdown_tx);
+                let (epoch_tx, epoch_rx) = tokio::sync::watch::channel::<u64>(0);
+                let server = Server::new(storage, epoch_tx, epoch_rx, shutdown_tx);
                 let queue_client: QueueClient = capnp_rpc::new_client(server);
                 // Signal readiness once bound and client is created
                 let _ = ready_tx.send(());


### PR DESCRIPTION
Replace `tokio::sync::Notify` with a versioned `watch<u64>` epoch channel to improve server wakeup reliability.

The previous `Notify` mechanism could lead to missed wakeups if a poller was not actively awaiting a notification when `notify_one()` was called. The `watch<u64>` channel, by incrementing an epoch, ensures that all pollers, regardless of when they start listening, will eventually observe the epoch change and wake up, preventing missed notifications and ensuring all clients are promptly informed of new items or visibility changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-2daf03c8-4543-4c3d-97f2-21241c687672">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2daf03c8-4543-4c3d-97f2-21241c687672">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

