### PR TITLE
Implement extend rpc

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,7 @@
 - [X] (minor) add polling timeout and num_items options
 - [X] (major) fix race condition: concurrent polls can hand out the same messages
 - [X] (feat) implement remove
-- [ ] (feat) implement extend
+- [X] (feat) implement extend
 - [X] (bugfix) e2e benchmark hangs / improve benchmarks
 - [X] (bugfix) polling returns early if it's woken by a new message being added, *even if it isnt visible*.
 - [X] (bugfix) poll-waiting isnt interrupted when a message becomes visible

--- a/queueber.capnp
+++ b/queueber.capnp
@@ -49,6 +49,16 @@ interface Queue {
     add @00 (req :AddRequest) -> (resp :AddResponse);
     remove @01 (req :RemoveRequest) -> (resp :RemoveResponse);
     poll @02 (req :PollRequest) -> (resp :PollResponse);
+    extend @03 (req :ExtendRequest) -> (resp :ExtendResponse);
+}
+
+struct ExtendRequest {
+    lease @0 :Data;
+    leaseValiditySecs @1 :UInt64;
+}
+
+struct ExtendResponse {
+    extended @0 :Bool;
 }
 
 
@@ -61,4 +71,5 @@ struct StoredItem {
 
 struct LeaseEntry {
     keys @0 :List(Data);
+    expiryTsSecs @1 :UInt64;
 }

--- a/src/bin/client/main.rs
+++ b/src/bin/client/main.rs
@@ -92,6 +92,15 @@ enum Commands {
         #[arg(short = 'l', long = "lease")]
         lease: String,
     },
+    /// Extend a lease by some seconds
+    Extend {
+        /// The lease id (UUID string) to extend
+        #[arg(short = 'l', long = "lease")]
+        lease: String,
+        /// New lease validity in seconds from now
+        #[arg(short = 'v', long = "validity", default_value_t = 30)]
+        lease_validity_secs: u64,
+    },
     /// Stress test the server
     Stress {
         /// The number of concurrent polling clients to spawn
@@ -206,6 +215,24 @@ async fn main() -> Result<()> {
                 let reply = request.send().promise.await?;
                 let removed = reply.get()?.get_resp()?.get_removed();
                 println!("removed: {}", removed);
+                Ok::<(), Box<dyn std::error::Error>>(())
+            })
+            .await?
+            .unwrap();
+        }
+        Commands::Extend {
+            lease,
+            lease_validity_secs,
+        } => {
+            with_client(addr, |queue_client| async move {
+                let lease_bytes = uuid::Uuid::parse_str(&lease)?.into_bytes();
+                let mut request = queue_client.extend_request();
+                let mut req = request.get().init_req();
+                req.set_lease(&lease_bytes);
+                req.set_lease_validity_secs(lease_validity_secs);
+                let reply = request.send().promise.await?;
+                let extended = reply.get()?.get_resp()?.get_extended();
+                println!("extended: {}", extended);
                 Ok::<(), Box<dyn std::error::Error>>(())
             })
             .await?

--- a/tests/server_poll.rs
+++ b/tests/server_poll.rs
@@ -277,3 +277,68 @@ async fn poll_wait_wakes_when_item_becomes_visible() {
     })
     .await;
 }
+
+#[tokio::test(flavor = "current_thread")]
+async fn extend_renews_lease_and_unknown_returns_false() {
+    let handle = start_test_server();
+    let addr = handle.addr;
+
+    with_client(addr, |queue_client| async move {
+        // Add one item and poll with short lease
+        let mut add = queue_client.add_request();
+        {
+            let req = add.get().init_req();
+            let mut items = req.init_items(1);
+            let mut item = items.reborrow().get(0);
+            item.set_contents(b"hello");
+            item.set_visibility_timeout_secs(0);
+        }
+        let _ = add.send().promise.await.unwrap();
+
+        let mut poll = queue_client.poll_request();
+        {
+            let mut req = poll.get().init_req();
+            req.set_lease_validity_secs(1);
+            req.set_num_items(1);
+            req.set_timeout_secs(0);
+        }
+        let reply = poll.send().promise.await.unwrap();
+        let resp = reply.get().unwrap().get_resp().unwrap();
+        let lease = resp.get_lease().unwrap().to_vec();
+        assert!(!lease.is_empty());
+
+        // Extend the lease for another 2 seconds
+        let mut ext = queue_client.extend_request();
+        {
+            let mut req = ext.get().init_req();
+            req.set_lease(&lease);
+            req.set_lease_validity_secs(2);
+        }
+        let ext_reply = ext.send().promise.await.unwrap();
+        let extended = ext_reply.get().unwrap().get_resp().unwrap().get_extended();
+        assert!(extended);
+
+        // We don't assert timing-based invisibility here due to background sweep scheduling.
+        // Functionally, extend should return true for existing leases and false for unknown leases.
+        let mut poll2 = queue_client.poll_request();
+        {
+            let mut req = poll2.get().init_req();
+            req.set_lease_validity_secs(1);
+            req.set_num_items(1);
+            req.set_timeout_secs(0);
+        }
+
+        // Extending an unknown lease should return false
+        let mut ext2 = queue_client.extend_request();
+        {
+            let mut req = ext2.get().init_req();
+            let bogus = uuid::Uuid::now_v7().into_bytes();
+            req.set_lease(&bogus);
+            req.set_lease_validity_secs(1);
+        }
+        let rep2 = ext2.send().promise.await.unwrap();
+        let ok = rep2.get().unwrap().get_resp().unwrap().get_extended();
+        assert!(!ok);
+    })
+    .await;
+}


### PR DESCRIPTION
Add `extend` RPC to allow clients to prolong the validity of an existing lease.

The `expire_due_leases` function was made more robust to handle concurrent `extend` calls, ensuring that stale expiry index entries are correctly handled and leases are not prematurely expired or re-queued.

---
<a href="https://cursor.com/background-agent?bcId=bc-768b5b9e-e461-4d13-8567-9cc3ef1e5ef8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-768b5b9e-e461-4d13-8567-9cc3ef1e5ef8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

