### PR TITLE
Deduplicate background tasks

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -211,7 +211,9 @@ impl crate::protocol::queue::Server for Server {
         Promise::from_future(async move {
             let removed = tokio::task::Builder::new()
                 .name("remove_in_progress_item")
-                .spawn_blocking(move || storage.remove_in_progress_item(id_owned.as_slice(), &lease))?
+                .spawn_blocking(move || {
+                    storage.remove_in_progress_item(id_owned.as_slice(), &lease)
+                })?
                 .await
                 .map_err(Into::<Error>::into)??;
 


### PR DESCRIPTION
Verify background task deduplication for lease expiry and visibility wakeup.

The session focused on confirming that `lease_expiry` and `visibility_wakeup` tasks are spawned exactly once via `spawn_background_tasks` in `src/bin/queueber/main.rs`. The attached diff includes a minor formatting change to a `spawn_blocking` call in `src/server.rs`.

---
<a href="https://cursor.com/background-agent?bcId=bc-020bf5ff-7c1c-41e6-a2f4-5a185eb01ab9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-020bf5ff-7c1c-41e6-a2f4-5a185eb01ab9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

