### PR TITLE
Fix lease extension expiry index transaction

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -468,6 +468,7 @@ impl Storage {
             serialize::write_message(&mut buf, &out)?;
             txn.put(lease_key.as_ref(), &buf)?;
         }
+        txn.commit()?;
         Ok(true)
     }
 }


### PR DESCRIPTION
Commit the transaction in `extend_lease` to ensure lease expiry updates are persisted atomically.

---
<a href="https://cursor.com/background-agent?bcId=bc-db5fe7c7-6fd6-4fb6-a238-371ecb9fd5a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-db5fe7c7-6fd6-4fb6-a238-371ecb9fd5a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

