### PR TITLE
Implement and correct field names

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -32,7 +32,7 @@
 - [ ] (perf) improve poll wakeups
 - [ ] (perf) per-worker accept via `SO_REUSEPORT`
 - [ ] (perf) buffer/message reuse to reduce allocations on hot paths (if that makes sense for capnp)
-- [ ] (minor) rename keys to ids in `LeaseEntry`, or actually put keys in there. either way
+- [X] (minor) rename keys to ids in `LeaseEntry`, or actually put keys in there. either way
 - [ ] (minor) make `add_available_item_from_parts` wrap `add_available_items_from_parts`, not the other way around
 - [ ] (minor) use a mockable clock when generating uuidv7s
 - [ ] (perf) reduce unnecessary allocs, such as when copying data or allocating buffers. some is called out in code comments

--- a/docs/db-access-patterns.md
+++ b/docs/db-access-patterns.md
@@ -13,7 +13,7 @@ This document describes how the RocksDB storage layer is organized and the acces
 
 - `in_progress/<id>`: Main record for an item that has been polled and is currently leased. Value is the same `stored_item` payload as in `available` (including the original `visibility_ts_index_key`).
 
-- `leases/<lease_bytes>`: A lease entry. Value is a Cap'n Proto `lease_entry` with a list of item ids (`keys`) currently owned by the lease.
+- `leases/<lease_bytes>`: A lease entry. Value is a Cap'n Proto `lease_entry` with a list of item ids (`ids`) currently owned by the lease.
 
 - `lease_expiry/<u64:expiry_ts_be>/<lease_bytes>`: Index from expiry timestamp to `leases/<lease_bytes>` key for the sweeper.
 
@@ -37,7 +37,7 @@ Key helpers and parsers are in `src/dbkeys.rs`. Timestamps are encoded as 8-byte
       - If the index entry (`idx_key`) is already gone, skip.
       - Otherwise treat it as a stale/orphaned index and self-heal by deleting `idx_key` within the same transaction and commit; skip the item.
   - Accumulate up to `n` items. If any were claimed, write a lease entry:
-    - `put leases/<lease> -> lease_entry(keys=[ids...])`
+    - `put leases/<lease> -> lease_entry(ids=[ids...])`
     - `put lease_expiry/<expiry>/<lease> -> leases/<lease>`
   - If zero items were claimed, no lease is written.
 

--- a/queueber.capnp
+++ b/queueber.capnp
@@ -70,6 +70,6 @@ struct StoredItem {
 }
 
 struct LeaseEntry {
-    keys @0 :List(Data); # TODO: rename to ids which is what it is rn
+    ids @0 :List(Data);
     expiryTsSecs @1 :UInt64;
 }


### PR DESCRIPTION
Rename `LeaseEntry.keys` to `LeaseEntry.ids` to accurately reflect its content.

---
<a href="https://cursor.com/background-agent?bcId=bc-9270cd94-16d1-436e-8b10-cdfb60edb184">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9270cd94-16d1-436e-8b10-cdfb60edb184">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

