### PR TITLE
Implement reuseport functionality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ env:
   # TODO: for some reason it's not noticing this in .cargo/config.toml, so we have to set it here
   # rustflags = ["--cfg", "tokio_unstable"] # for tokio console
   RUSTFLAGS: --cfg tokio_unstable
+  RUST_BACKTRACE: 1
 
 jobs:
   test:
@@ -37,8 +38,8 @@ jobs:
     - name: Build
       run: cargo build --verbose
 
-    - name: Run tests
-      run: cargo test --verbose
+    - name: Run tests (verbose, no capture)
+      run: cargo test --verbose -- --nocapture
 
     - name: Run Clippy
       run: cargo clippy --all-targets --all-features -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1468,6 +1468,7 @@ dependencies = [
  "rand 0.8.5",
  "rocksdb",
  "scopeguard",
+ "socket2 0.5.10",
  "tempfile",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ tracing-subscriber = { version = "0.3.19", features = [
 console-subscriber = "0.4"
 uuid = { version = "1.18.0", features = ["std", "v4", "v7", "zerocopy"] }
 rand = "0.8"
+socket2 = "0.5"
 
 [build-dependencies]
 capnpc = "0.21.2"

--- a/TODO.md
+++ b/TODO.md
@@ -30,7 +30,7 @@
 - [X] (perf) add `--workers` CLI flag and name RPC worker threads
 - [ ] (perf) improve performance
 - [ ] (perf) improve poll wakeups
-- [ ] (perf) per-worker accept via `SO_REUSEPORT`
+- [X] (perf) per-worker accept via `SO_REUSEPORT`
 - [ ] (perf) buffer/message reuse to reduce allocations on hot paths (if that makes sense for capnp)
 - [ ] (minor) rename keys to ids in `LeaseEntry`, or actually put keys in there. either way
 - [ ] (minor) make `add_available_item_from_parts` wrap `add_available_items_from_parts`, not the other way around

--- a/src/bin/queueber/main.rs
+++ b/src/bin/queueber/main.rs
@@ -1,4 +1,7 @@
-use std::{net::ToSocketAddrs, path::PathBuf};
+use std::{
+    net::{SocketAddr, ToSocketAddrs},
+    path::PathBuf,
+};
 
 use capnp_rpc::{RpcSystem, rpc_twoparty_capnp, twoparty};
 use clap::Parser;
@@ -8,8 +11,9 @@ use queueber::{
     server::Server,
     storage::{RetriedStorage, Storage},
 };
+use socket2::{Domain, Protocol, Socket, Type};
 use std::sync::Arc;
-use tokio::sync::{Notify, mpsc};
+use tokio::sync::Notify;
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
 // see https://github.com/capnproto/capnproto-rust/blob/master/example/addressbook_send/addressbook_send.rs
@@ -81,15 +85,13 @@ async fn main() -> Result<()> {
     // Build a small pool of RPC workers. Each worker runs a single-threaded runtime with a LocalSet
     let worker_count = compute_worker_count(args.workers);
     tracing::info!("using {} worker threads", worker_count);
-    let mut senders = Vec::with_capacity(worker_count);
     let mut worker_handles = Vec::with_capacity(worker_count);
     for i in 0..worker_count {
-        let (tx, mut rx) = mpsc::channel::<tokio::net::TcpStream>(1024);
-        senders.push(tx);
-
         let storage_cloned = Arc::clone(&storage);
         let notify_cloned = Arc::clone(&notify);
         let shutdown_tx_cloned = shutdown_tx.clone();
+        let mut shutdown_rx_worker = shutdown_rx.clone();
+        let addr_for_worker: SocketAddr = addr;
 
         let thread_name = format!("rpc-worker-{}", i);
         let handle = std::thread::Builder::new()
@@ -107,34 +109,51 @@ async fn main() -> Result<()> {
                     let local = tokio::task::LocalSet::new();
                     local
                         .run_until(async move {
+                            // Per-worker listener using SO_REUSEPORT
+                            let std_listener = bind_reuseport(addr_for_worker).expect("bind reuseport listener");
+                            std_listener
+                                .set_nonblocking(true)
+                                .expect("set nonblocking");
+                            let listener = tokio::net::TcpListener::from_std(std_listener)
+                                .expect("tokio listener from std");
+
                             let mut conn_id: u64 = 0;
-                            while let Some(stream) = rx.recv().await {
-                                let client = queue_client.clone();
-                                let this_conn = conn_id;
-                                conn_id = conn_id.wrapping_add(1);
-                                let _jh = tokio::task::Builder::new()
-                                    .name("rpc_server")
-                                    .spawn_local(async move {
-                                        let (reader, writer) =
-                                            tokio_util::compat::TokioAsyncReadCompatExt::compat(
-                                                stream,
-                                            )
-                                            .split();
-                                        let network = twoparty::VatNetwork::new(
-                                            futures::io::BufReader::new(reader),
-                                            futures::io::BufWriter::new(writer),
-                                            rpc_twoparty_capnp::Side::Server,
-                                            Default::default(),
-                                        );
-                                        let rpc_system =
-                                            RpcSystem::new(Box::new(network), Some(client.client));
-                                        let _jh2 = tokio::task::Builder::new()
-                                            .name("rpc_system")
-                                            .spawn_local(rpc_system)
+                            loop {
+                                tokio::select! {
+                                    _ = async { if *shutdown_rx_worker.borrow() { } else { let _ = shutdown_rx_worker.changed().await; } } => {
+                                        break;
+                                    }
+                                    accept_res = listener.accept() => {
+                                        let (stream, _) = accept_res.expect("accept ok");
+                                        let _ = stream.set_nodelay(true);
+                                        let client = queue_client.clone();
+                                        let this_conn = conn_id;
+                                        conn_id = conn_id.wrapping_add(1);
+                                        let _jh = tokio::task::Builder::new()
+                                            .name("rpc_server")
+                                            .spawn_local(async move {
+                                                let (reader, writer) =
+                                                    tokio_util::compat::TokioAsyncReadCompatExt::compat(
+                                                        stream,
+                                                    )
+                                                    .split();
+                                                let network = twoparty::VatNetwork::new(
+                                                    futures::io::BufReader::new(reader),
+                                                    futures::io::BufWriter::new(writer),
+                                                    rpc_twoparty_capnp::Side::Server,
+                                                    Default::default(),
+                                                );
+                                                let rpc_system =
+                                                    RpcSystem::new(Box::new(network), Some(client.client));
+                                                let _jh2 = tokio::task::Builder::new()
+                                                    .name("rpc_system")
+                                                    .spawn_local(rpc_system)
+                                                    .unwrap();
+                                                let _ = this_conn; // reserved for future naming/metrics
+                                            })
                                             .unwrap();
-                                        let _ = this_conn; // reserved for future naming/metrics
-                                    })
-                                    .unwrap();
+                                    }
+                                }
                             }
                         })
                         .await;
@@ -145,38 +164,41 @@ async fn main() -> Result<()> {
         worker_handles.push(handle);
     }
 
-    let listener = tokio::net::TcpListener::bind(&addr).await?;
-    let accept_outcome: Result<()> = 'accept: {
-        let mut next = 0usize;
-        loop {
-            tokio::select! {
-                _ = async { if *shutdown_rx.borrow() { } else { let _ = shutdown_rx.changed().await; } } => {
-                    tracing::info!("accept loop shutting down due to shutdown signal");
-                    break 'accept Ok(())
-                }
-                accept = listener.accept() => {
-                    let (stream, _)= accept?;
-                    stream.set_nodelay(true)?;
-                    let idx = next % senders.len();
-                    next = next.wrapping_add(1);
-                    senders[idx].send(stream).await?;
-                }
-            }
+    // Wait for shutdown signal, then join workers
+    let _ = async {
+        if *shutdown_rx.borrow() {
+        } else {
+            let _ = shutdown_rx.changed().await;
         }
-    };
-    tracing::info!("accept loop exiting");
-
-    drop(senders);
+    }
+    .await;
+    tracing::info!("shutdown signal received; joining workers");
     for handle in worker_handles {
         let _ = handle.join();
     }
     tracing::info!("workers joined; main loop exiting");
-    accept_outcome
+    Ok(())
+}
+
+fn bind_reuseport(addr: SocketAddr) -> std::io::Result<std::net::TcpListener> {
+    let domain = match addr {
+        SocketAddr::V4(_) => Domain::IPV4,
+        SocketAddr::V6(_) => Domain::IPV6,
+    };
+    let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
+    socket.set_reuse_address(true)?;
+    // SO_REUSEPORT for per-worker accept
+    socket.set_reuse_port(true)?;
+    socket.bind(&addr.into())?;
+    // Larger backlog can help under high accept rates
+    socket.listen(4096)?;
+    Ok(socket.into())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::compute_worker_count;
+    use super::{bind_reuseport, compute_worker_count};
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
     #[test]
     fn compute_workers_uses_arg_when_provided() {
@@ -187,5 +209,16 @@ mod tests {
     fn compute_workers_falls_back_to_available_parallelism() {
         let n = compute_worker_count(None);
         assert!(n >= 1);
+    }
+
+    #[test]
+    fn bind_reuseport_allows_multiple_binds() {
+        // Bind first on ephemeral port 0
+        let addr1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
+        let l1 = bind_reuseport(addr1).expect("first bind");
+        let port = l1.local_addr().unwrap().port();
+        let addr2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
+        // Second bind on same port should succeed due to SO_REUSEPORT
+        let _l2 = bind_reuseport(addr2).expect("second bind");
     }
 }


### PR DESCRIPTION
Implement per-worker TCP listeners using `SO_REUSEPORT` to improve connection distribution and remove the central accept loop.

---
<a href="https://cursor.com/background-agent?bcId=bc-5fe35e9c-e228-442f-8dcc-12788147c3b0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5fe35e9c-e228-442f-8dcc-12788147c3b0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

