### PR TITLE
Implement the new feature

### DIFF
--- a/queueber.capnp
+++ b/queueber.capnp
@@ -72,4 +72,7 @@ struct StoredItem {
 struct LeaseEntry {
     ids @0 :List(Data);
     expiryTsSecs @1 :UInt64;
+    # exact lease-expiry index key bytes for this lease's current expiry
+    # used to delete/update the index without scanning on extend
+    expiryIndexKey @2 :Data;
 }


### PR DESCRIPTION
Store lease expiry index key in `LeaseEntry` to enable direct deletion on extend and prevent duplicate index entries.

The previous `extend` operation relied on a prefix scan to find and delete old expiry index entries, which was inefficient and prone to leaving duplicate entries. This change stores the exact expiry index key within the `LeaseEntry` itself, allowing for a direct key deletion during `extend` and ensuring only one expiry index entry exists per lease. It also adds a cleanup mechanism in the sweeper for robustness.

---
<a href="https://cursor.com/background-agent?bcId=bc-8a36cf37-0211-4e8d-b10b-44e0fea7e95c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8a36cf37-0211-4e8d-b10b-44e0fea7e95c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

