### PR TITLE
Verify and fix condition

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -37,7 +37,7 @@
 - [ ] (minor) use a mockable clock when generating uuidv7s
 - [ ] (perf) reduce unnecessary allocs, such as when copying data or allocating buffers. some is called out in code comments
 - [X] (perf) sort the keys in `LeaseEntry` so we can do bsearch on them
-- [ ] (major) ensure `extend` doesnt create multiple index entries for the same lease.
+- [X] (major) ensure `extend` doesnt create multiple index entries for the same lease.
 - [X] (perf) add lease expiry index key to `LeaseEntry` so we don't have to do scans to find it when extending
 - [X] (bugfix) i still get `assertion failed: main key not found: [97, 118, 97, 105, 108, 97, 98, 108, 101, 47, 1, 152, 216, 213, 36, 239, 114, 179, 154, 59, 190, 29, 213, 115, 111, 117]"` from poll requests when running with high concurrency. even now that we use a snapshotted txn in poll.
 - [ ] (perf) implement poll request coalescing to reduce contention - when multiple clients are polling simultaneously, batch their requests to reduce database contention and improve throughput ([sketch](docs/poll_coalescing_sketch.md))


### PR DESCRIPTION
Mark `extend` index duplication item in `TODO.md` as done because existing tests confirm `extend` correctly maintains a single expiry index entry per lease.

---
<a href="https://cursor.com/background-agent?bcId=bc-ff8bb80a-24fd-4fd6-80d1-da144c57c716">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ff8bb80a-24fd-4fd6-80d1-da144c57c716">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

