### PR TITLE
Implement and stress test optimization

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -36,7 +36,7 @@
   - guard expensive debug logging/UUID formatting behind level checks; sample logs under load
   - evaluate pessimistic transactions under contention; compare retries vs lock waits
   - reduce redundant copies (to_vec, id conversions); prefer borrowing/Arc reuse across async boundaries
-  - pre-size vectors/lists based on `n` to avoid reallocs in poll and lease building
+  - [X] pre-size vectors/lists based on `n` to avoid reallocs in poll and lease building
 - [ ] (perf) improve poll wakeups
 - [X] (perf) per-worker accept via `SO_REUSEPORT`
 - [ ] (perf) buffer/message reuse to reduce allocations on hot paths (if that makes sense for capnp)


### PR DESCRIPTION
Pre-size Cap'n Proto message builders in `storage.rs` to reduce reallocations during message construction.

While current stress tests show throughput differences within noise, this change is correctness-neutral and is expected to improve performance under higher item sizes or larger numbers of items by avoiding dynamic memory reallocations.

---
<a href="https://cursor.com/background-agent?bcId=bc-6d9cacf0-ff7b-4662-961d-f888028a1898">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6d9cacf0-ff7b-4662-961d-f888028a1898">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

