### PR TITLE
Tune rocksdb settings based on stress test

### DIFF
--- a/baseline_stress.txt
+++ b/baseline_stress.txt
@@ -1,4 +1,8 @@
-[2m2025-08-27T14:08:22.706492Z[0m [32m INFO[0m [2mqueueber[0m[2m:[0m using 4 worker threads
+[2m2025-08-27T14:30:13.105551Z[0m [32m INFO[0m [2mqueueber[0m[2m:[0m using 4 worker threads
 Running client with args: -p 2 -a 2 -r0 -d 10
-add: 1011560 (202273.0/s), poll: 9940 (1987.6/s), remove: 9940 (1987.6/s), extend: 2 (0.4/s)
-[2m2025-08-27T14:08:33.299615Z[0m [33m WARN[0m [2mqueueber::storage[0m[2m:[0m RocksDB Busy: giving up after max retries [3moperation[0m[2m=[0mget_next_available_entries_with_lease [3mattempts[0m[2m=[0m9
+[2m2025-08-27T14:30:18.810517Z[0m [33m WARN[0m [2mqueueber::storage[0m[2m:[0m RocksDB Busy: giving up after max retries [3moperation[0m[2m=[0mget_next_available_entries_with_lease [3mattempts[0m[2m=[0m9
+add: 995060 (198971.5/s), poll: 10790 (2157.6/s), remove: 10790 (2157.6/s), extend: 2 (0.4/s)
+add: 799400 (159829.7/s), poll: 18260 (3650.9/s), remove: 18260 (3650.9/s), extend: 3 (0.6/s)
+Waiting for server to exit...
+Server exited with code 137
+Client exited with code 101

--- a/baseline_stress.txt
+++ b/baseline_stress.txt
@@ -1,0 +1,4 @@
+[2m2025-08-27T14:08:22.706492Z[0m [32m INFO[0m [2mqueueber[0m[2m:[0m using 4 worker threads
+Running client with args: -p 2 -a 2 -r0 -d 10
+add: 1011560 (202273.0/s), poll: 9940 (1987.6/s), remove: 9940 (1987.6/s), extend: 2 (0.4/s)
+[2m2025-08-27T14:08:33.299615Z[0m [33m WARN[0m [2mqueueber::storage[0m[2m:[0m RocksDB Busy: giving up after max retries [3moperation[0m[2m=[0mget_next_available_entries_with_lease [3mattempts[0m[2m=[0m9

--- a/tuned_stress.txt
+++ b/tuned_stress.txt
@@ -1,0 +1,7 @@
+[2m2025-08-27T14:34:08.980814Z[0m [32m INFO[0m [2mqueueber[0m[2m:[0m using 4 worker threads
+Running client with args: -p 2 -a 2 -r0 -d 10
+[2m2025-08-27T14:34:14.298827Z[0m [33m WARN[0m [2mqueueber::storage[0m[2m:[0m RocksDB Busy: giving up after max retries [3moperation[0m[2m=[0mget_next_available_entries_with_lease [3mattempts[0m[2m=[0m9
+add: 960960 (192155.6/s), poll: 3620 (723.9/s), remove: 3620 (723.9/s), extend: 2 (0.4/s)
+Waiting for server to exit...
+Server exited with code 137
+Client exited with code 101

--- a/tuned_stress_v2.txt
+++ b/tuned_stress_v2.txt
@@ -1,0 +1,8 @@
+[2m2025-08-27T14:36:12.222184Z[0m [32m INFO[0m [2mqueueber[0m[2m:[0m using 4 worker threads
+Running client with args: -p 2 -a 2 -r0 -d 10
+add: 847390 (169439.5/s), poll: 4440 (887.8/s), remove: 4440 (887.8/s), extend: 2 (0.4/s)
+[2m2025-08-27T14:36:18.756465Z[0m [33m WARN[0m [2mqueueber::storage[0m[2m:[0m RocksDB Busy: giving up after max retries [3moperation[0m[2m=[0mget_next_available_entries_with_lease [3mattempts[0m[2m=[0m9
+add: 511830 (102346.0/s), poll: 10030 (2005.6/s), remove: 10030 (2005.6/s), extend: 3 (0.6/s)
+Waiting for server to exit...
+Server exited with code 137
+Client exited with code 101


### PR DESCRIPTION
Propose RocksDB tunings to improve performance under load, though initial `stress.sh` results show a regression.

The tunings include increasing parallelism, enabling bloom filters, optimizing block-based table options, and adjusting compaction/write path settings (e.g., `set_level_compaction_dynamic_level_bytes`, `set_allow_concurrent_memtable_write`, `set_enable_pipelined_write`, and disabling compression). Under `stress.sh` (args: `-p 2 -a 2 -r0 -d 10`), baseline 'add' throughput was ~198k/s (first interval) and 'poll' ~2.1k/s. With tunings, 'add' throughput dropped to ~169k/s and 'poll' to ~0.8k/s in the first interval. 'RocksDB Busy' warnings persist, suggesting these tunings did not resolve the bottleneck for this specific workload.

---
<a href="https://cursor.com/background-agent?bcId=bc-8e152c83-9bdc-4dd6-99dd-04994397fd27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8e152c83-9bdc-4dd6-99dd-04994397fd27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

