### PR TITLE
Implement and stress test optimization

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -116,9 +116,10 @@ impl crate::protocol::queue::Server for Server {
 
         // Generate ids upfront and copy request data into owned memory so we can move
         // it into a blocking task (capnp readers are not Send).
-        let ids: Vec<Vec<u8>> = items
+        // Store ids inline as [u8;16] to avoid per-id heap allocations.
+        let ids: Vec<[u8; 16]> = items
             .iter()
-            .map(|_| uuid::Uuid::now_v7().as_bytes().to_vec())
+            .map(|_| uuid::Uuid::now_v7().into_bytes())
             .collect();
 
         let items_owned = items
@@ -135,7 +136,6 @@ impl crate::protocol::queue::Server for Server {
 
         let storage = Arc::clone(&self.storage);
         let notify = Arc::clone(&self.notify);
-        let ids_for_resp = ids.clone();
 
         Promise::from_future(async move {
             // Offload RocksDB work to the blocking thread pool.
@@ -150,11 +150,8 @@ impl crate::protocol::queue::Server for Server {
             }
 
             // Build the response on the RPC thread.
-            let mut ids_builder = results
-                .get()
-                .init_resp()
-                .init_ids(ids_for_resp.len() as u32);
-            for (i, id) in ids_for_resp.iter().enumerate() {
+            let mut ids_builder = results.get().init_resp().init_ids(ids.len() as u32);
+            for (i, id) in ids.iter().enumerate() {
                 ids_builder.set(i as u32, id);
             }
             Ok(())
@@ -176,13 +173,13 @@ impl crate::protocol::queue::Server for Server {
         let mut lease: [u8; 16] = [0; 16];
         lease.copy_from_slice(lease_bytes);
 
-        // Own the id bytes so they can be moved across await boundaries.
-        let id_owned = id.to_vec();
+        // Own the id bytes so they can be moved across await boundaries with minimal copying.
+        let id_owned: std::sync::Arc<[u8]> = std::sync::Arc::from(id);
 
         let storage = Arc::clone(&self.storage);
         Promise::from_future(async move {
             let removed = storage
-                .remove_in_progress_item(id_owned.as_slice(), &lease)
+                .remove_in_progress_item(id_owned.as_ref(), &lease)
                 .await?;
 
             results.get().init_resp().set_removed(removed);


### PR DESCRIPTION
Optimize `src/server.rs` by reducing heap allocations and data copying for improved performance.

UUIDs are now stored inline as `[u8; 16]` within a `Vec`, eliminating per-ID heap allocations. The `ids` vector is no longer cloned for the response, and the `remove` operation uses `Arc<[u8]>` for the ID to enable cheap moves across `await` boundaries without a full `to_vec`.

---
<a href="https://cursor.com/background-agent?bcId=bc-42408d10-0188-4c0c-805b-8b767b41637b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-42408d10-0188-4c0c-805b-8b767b41637b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

