### PR TITLE
Modify benchmark ci to skip tests

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -49,9 +49,6 @@ jobs:
       - name: Build benches
         run: cargo build --benches --locked
 
-      - name: Run clippy (sanity)
-        run: |
-          cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Run Criterion benches
         run: |


### PR DESCRIPTION
Remove `cargo test` and `cargo clippy` from the benchmark CI task.

The benchmark CI task should focus solely on building and running benchmarks, not on general testing or linting.

---
<a href="https://cursor.com/background-agent?bcId=bc-96006dca-6db7-4e85-ab9c-1ed32f7cbbcf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-96006dca-6db7-4e85-ab9c-1ed32f7cbbcf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>