### PR TITLE
Create dockerfile and ci build task

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,56 @@
+name: Docker Image
+
+on:
+  push:
+    branches: [ master, main ]
+    paths:
+      - 'Dockerfile'
+      - '.github/workflows/docker.yml'
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'build.rs'
+  pull_request:
+    branches: [ master, main ]
+    paths:
+      - 'Dockerfile'
+      - '.github/workflows/docker.yml'
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'build.rs'
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: queueber
+
+jobs:
+  build:
+    name: Build multi-arch image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: |
+            ${{ github.repository }}:${{ github.sha }}
+          build-args: |
+            RUST_TOOLCHAIN=nightly
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+

--- a/TODO.md
+++ b/TODO.md
@@ -62,7 +62,7 @@
 - [ ] (productionize) admin operations: safe drain, purge, and stats endpoints
 - [ ] (productionize) abstract a mockable clock for leases/visibility to enable deterministic tests
 - [X] (productionize) release profile tuning: LTO, codegen-units, panic=abort (if acceptable), symbol levels
-- [ ] (productionize) packaging: Dockerfile (non-root, minimal base, HEALTHCHECK), multi-arch builds
+- [X] (productionize) packaging: Dockerfile (non-root, minimal base, HEALTHCHECK), multi-arch builds
 - [ ] (productionize) Kubernetes/Helm: liveness/readiness probes, resource limits/requests, PDB, PV, ConfigMap-based configuration
 - [ ] (productionize) systemd unit: restart policy, sandboxing, rlimits, service user/group
 - [ ] (productionize) repository hygiene: add LICENSE and CONTRIBUTING.md


### PR DESCRIPTION
Add a Dockerfile, .dockerignore, and a CI workflow to build a multi-architecture Docker image for production readiness.

---
<a href="https://cursor.com/background-agent?bcId=bc-5ab45d37-7fd1-4d2a-bb6f-4d612edf8815">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5ab45d37-7fd1-4d2a-bb6f-4d612edf8815">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

