### PR TITLE
Build and push Docker image to ghcr

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Ignore build artifacts and VCS metadata
+/target
+**/target
+/.git
+/.github
+/.vscode
+/.idea
+/node_modules
+/tmp
+/profile.json.gz
+/criterion-summary.json
+/tests
+/benches
+/docs

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,56 @@
+name: docker-publish
+
+on:
+  push:
+    branches: [ "master" ]
+    tags: [ "v*" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=tag
+            type=ref,event=branch
+            type=sha
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{ github.ref == 'refs/heads/master' && format('ghcr.io/{0}:latest', github.repository) || '' }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+# --- Builder stage ---
+FROM rust:bookworm AS builder
+
+# Install dependencies for building (Cap'n Proto CLI, compilers, and C/C++ libs)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        capnproto \
+        libclang-19-dev \
+        clang \
+        cmake \
+        pkg-config \
+        make \
+        g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Leverage Docker layer caching: copy manifests first
+COPY Cargo.toml Cargo.lock rust-toolchain.toml build.rs queueber.capnp rust.capnp ./
+COPY src ./src
+
+# Build release binary (rust-toolchain.toml pins nightly)
+RUN cargo build --release --bin queueber
+
+# --- Runtime stage ---
+FROM debian:bookworm-slim AS runtime
+
+# Minimal runtime deps and healthcheck tool
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        tzdata \
+        netcat-openbsd \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user and data dir
+RUN useradd -u 10001 -r -m -d /home/queueber queueber && \
+    mkdir -p /var/lib/queueber && \
+    chown -R queueber:queueber /var/lib/queueber
+
+# Copy binary
+COPY --from=builder /app/target/release/queueber /usr/local/bin/queueber
+
+USER queueber
+ENV RUST_LOG=info
+EXPOSE 9090
+
+# Basic TCP healthcheck on the Cap'n Proto port
+HEALTHCHECK --interval=10s --timeout=2s --start-period=5s --retries=3 \
+  CMD nc -z 127.0.0.1 9090 || exit 1
+
+# Default entrypoint; can be overridden
+ENTRYPOINT ["/usr/local/bin/queueber", "--listen", "0.0.0.0:9090", "--data-dir", "/var/lib/queueber"]

--- a/TODO.md
+++ b/TODO.md
@@ -62,7 +62,7 @@
 - [ ] (productionize) admin operations: safe drain, purge, and stats endpoints
 - [ ] (productionize) abstract a mockable clock for leases/visibility to enable deterministic tests
 - [X] (productionize) release profile tuning: LTO, codegen-units, panic=abort (if acceptable), symbol levels
-- [ ] (productionize) packaging: Dockerfile (non-root, minimal base, HEALTHCHECK), multi-arch builds
+- [X] (productionize) packaging: Dockerfile (non-root, minimal base, HEALTHCHECK), multi-arch builds
 - [ ] (productionize) Kubernetes/Helm: liveness/readiness probes, resource limits/requests, PDB, PV, ConfigMap-based configuration
 - [ ] (productionize) systemd unit: restart policy, sandboxing, rlimits, service user/group
 - [X] (productionize) repository hygiene: add LICENSE and CONTRIBUTING.md


### PR DESCRIPTION
Add a Dockerfile and GitHub Actions workflow to build and push multi-arch images to GHCR.

---
<a href="https://cursor.com/background-agent?bcId=bc-ca8ccad3-9724-44c4-93e7-2f5b3ef5169e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ca8ccad3-9724-44c4-93e7-2f5b3ef5169e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

