### PR TITLE
Test and fix expired lease operations

### DIFF
--- a/tests/rpc_fuzz.rs
+++ b/tests/rpc_fuzz.rs
@@ -3,8 +3,8 @@ use std::sync::mpsc::sync_channel;
 
 use capnp_rpc::{RpcSystem, rpc_twoparty_capnp, twoparty};
 use futures::AsyncReadExt;
-use proptest::prelude::*;
 use proptest::prelude::ProptestConfig;
+use proptest::prelude::*;
 use proptest::strategy::Strategy;
 use queueber::protocol::queue;
 use queueber::storage::{RetriedStorage, Storage};


### PR DESCRIPTION
Reject operations on expired leases and add tests to verify this behavior before the sweeper runs.

---
<a href="https://cursor.com/background-agent?bcId=bc-793fce9a-a19c-45f7-90a7-426744339b82">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-793fce9a-a19c-45f7-90a7-426744339b82">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

