### PR TITLE
Implement optimization

### DIFF
--- a/benches/storage_bench.rs
+++ b/benches/storage_bench.rs
@@ -286,8 +286,14 @@ fn ensure_server_started() -> &'static ServerHandle {
                             let (reader, writer) =
                                 tokio_util::compat::TokioAsyncReadCompatExt::compat(stream).split();
                             let network = twoparty::VatNetwork::new(
-                                futures::io::BufReader::new(reader),
-                                futures::io::BufWriter::new(writer),
+                                futures::io::BufReader::with_capacity(
+                                    queueber::RPC_IO_BUFFER_BYTES,
+                                    reader,
+                                ),
+                                futures::io::BufWriter::with_capacity(
+                                    queueber::RPC_IO_BUFFER_BYTES,
+                                    writer,
+                                ),
                                 rpc_twoparty_capnp::Side::Server,
                                 Default::default(),
                             );
@@ -329,8 +335,8 @@ where
         stream.set_nodelay(true).unwrap();
         let (reader, writer) = tokio_util::compat::TokioAsyncReadCompatExt::compat(stream).split();
         let rpc_network = Box::new(twoparty::VatNetwork::new(
-            futures::io::BufReader::new(reader),
-            futures::io::BufWriter::new(writer),
+            futures::io::BufReader::with_capacity(queueber::RPC_IO_BUFFER_BYTES, reader),
+            futures::io::BufWriter::with_capacity(queueber::RPC_IO_BUFFER_BYTES, writer),
             rpc_twoparty_capnp::Side::Client,
             Default::default(),
         ));

--- a/src/bin/client/main.rs
+++ b/src/bin/client/main.rs
@@ -539,8 +539,8 @@ where
     stream.set_nodelay(true).unwrap();
     let (reader, writer) = tokio_util::compat::TokioAsyncReadCompatExt::compat(stream).split();
     let rpc_network = Box::new(twoparty::VatNetwork::new(
-        futures::io::BufReader::new(reader),
-        futures::io::BufWriter::new(writer),
+        futures::io::BufReader::with_capacity(queueber::RPC_IO_BUFFER_BYTES, reader),
+        futures::io::BufWriter::with_capacity(queueber::RPC_IO_BUFFER_BYTES, writer),
         rpc_twoparty_capnp::Side::Client,
         Default::default(),
     ));

--- a/src/bin/queueber/main.rs
+++ b/src/bin/queueber/main.rs
@@ -138,8 +138,8 @@ async fn main() -> Result<()> {
                                                     )
                                                     .split();
                                                 let network = twoparty::VatNetwork::new(
-                                                    futures::io::BufReader::new(reader),
-                                                    futures::io::BufWriter::new(writer),
+                                                    futures::io::BufReader::with_capacity(queueber::RPC_IO_BUFFER_BYTES, reader),
+                                                    futures::io::BufWriter::with_capacity(queueber::RPC_IO_BUFFER_BYTES, writer),
                                                     rpc_twoparty_capnp::Side::Server,
                                                     Default::default(),
                                                 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,3 +10,5 @@ pub mod storage;
 // Re-export commonly used types
 pub use crate::storage::RetriedStorage;
 pub use crate::storage::Storage;
+
+pub const RPC_IO_BUFFER_BYTES: usize = 64 * 1024;

--- a/tests/server_poll.rs
+++ b/tests/server_poll.rs
@@ -77,8 +77,8 @@ fn start_test_server() -> TestServerHandle {
                                 let (reader, writer) =
                                     tokio_util::compat::TokioAsyncReadCompatExt::compat(stream).split();
                                 let network = twoparty::VatNetwork::new(
-                                    futures::io::BufReader::new(reader),
-                                    futures::io::BufWriter::new(writer),
+                                    futures::io::BufReader::with_capacity(queueber::RPC_IO_BUFFER_BYTES, reader),
+                                    futures::io::BufWriter::with_capacity(queueber::RPC_IO_BUFFER_BYTES, writer),
                                     rpc_twoparty_capnp::Side::Server,
                                     Default::default(),
                                 );
@@ -116,8 +116,8 @@ where
     stream.set_nodelay(true).unwrap();
     let (reader, writer) = tokio_util::compat::TokioAsyncReadCompatExt::compat(stream).split();
     let rpc_network = Box::new(twoparty::VatNetwork::new(
-        futures::io::BufReader::new(reader),
-        futures::io::BufWriter::new(writer),
+        futures::io::BufReader::with_capacity(queueber::RPC_IO_BUFFER_BYTES, reader),
+        futures::io::BufWriter::with_capacity(queueber::RPC_IO_BUFFER_BYTES, writer),
         rpc_twoparty_capnp::Side::Client,
         Default::default(),
     ));

--- a/tests/startup_recovery.rs
+++ b/tests/startup_recovery.rs
@@ -90,8 +90,8 @@ fn start_server_on(data_dir: std::path::PathBuf, addr: SocketAddr) -> TestServer
                                 stream.set_nodelay(true).unwrap();
                                 let (reader, writer) = tokio_util::compat::TokioAsyncReadCompatExt::compat(stream).split();
                                 let network = twoparty::VatNetwork::new(
-                                    futures::io::BufReader::new(reader),
-                                    futures::io::BufWriter::new(writer),
+                                    futures::io::BufReader::with_capacity(queueber::RPC_IO_BUFFER_BYTES, reader),
+                                    futures::io::BufWriter::with_capacity(queueber::RPC_IO_BUFFER_BYTES, writer),
                                     rpc_twoparty_capnp::Side::Server,
                                     Default::default(),
                                 );
@@ -125,8 +125,8 @@ where
     stream.set_nodelay(true).unwrap();
     let (reader, writer) = tokio_util::compat::TokioAsyncReadCompatExt::compat(stream).split();
     let rpc_network = Box::new(twoparty::VatNetwork::new(
-        futures::io::BufReader::new(reader),
-        futures::io::BufWriter::new(writer),
+        futures::io::BufReader::with_capacity(queueber::RPC_IO_BUFFER_BYTES, reader),
+        futures::io::BufWriter::with_capacity(queueber::RPC_IO_BUFFER_BYTES, writer),
         rpc_twoparty_capnp::Side::Client,
         Default::default(),
     ));


### PR DESCRIPTION
Increase Cap'n Proto RPC I/O buffer sizes to improve performance.

---
<a href="https://cursor.com/background-agent?bcId=bc-9eb43bb7-5b34-4cb6-9629-e1084dc13d74">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9eb43bb7-5b34-4cb6-9629-e1084dc13d74">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

