### PR TITLE
Tighten key encodings

### DIFF
--- a/src/dbkeys.rs
+++ b/src/dbkeys.rs
@@ -4,15 +4,15 @@ use std::backtrace::Backtrace;
 
 use crate::errors::{Error, Result};
 
-/// Key for items that are available to be polled: `b"available/" + id`.
+/// Key for items that are available to be polled: raw `id` bytes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AvailableKey(Vec<u8>);
 
-/// Key for items that are currently in progress: `b"in_progress/" + id`.
+/// Key for items that are currently in progress: raw `id` bytes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InProgressKey(Vec<u8>);
 
-/// Visibility index key: `b"visibility_index/" + visible_ts_be + b"/" + id`.
+/// Visibility index key: `visible_ts_be + b"/" + id`.
 ///
 /// Notes:
 /// - Timestamp is encoded as 8-byte big-endian to preserve lexicographic
@@ -21,11 +21,11 @@ pub struct InProgressKey(Vec<u8>);
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VisibilityIndexKey(Vec<u8>);
 
-/// Lease key: `b"leases/" + lease_bytes`.
+/// Lease key: raw `lease_bytes`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LeaseKey(Vec<u8>);
 
-/// Lease expiry index key: `b"lease_expiry/" + expiry_ts_be + b"/" + lease_bytes`.
+/// Lease expiry index key: `expiry_ts_be + b"/" + lease_bytes`.
 ///
 /// Notes:
 /// - Timestamp is encoded as 8-byte big-endian to preserve lexicographic ordering by time.
@@ -33,13 +33,8 @@ pub struct LeaseKey(Vec<u8>);
 pub struct LeaseExpiryIndexKey(Vec<u8>);
 
 impl AvailableKey {
-    pub const PREFIX: &'static [u8] = b"available/";
-
     pub fn from_id(id: &[u8]) -> Self {
-        let mut key = Vec::with_capacity(Self::PREFIX.len() + id.len());
-        key.extend_from_slice(Self::PREFIX);
-        key.extend_from_slice(id);
-        Self(key)
+        Self(id.to_vec())
     }
 
     /// Returns the underlying database key bytes.
@@ -49,16 +44,14 @@ impl AvailableKey {
 
     /// Returns the item id suffix contained in this key.
     pub fn id_suffix(&self) -> &[u8] {
-        &self.0[Self::PREFIX.len()..]
+        &self.0
     }
 
-    /// Returns the item id suffix from a raw `available/` key without allocating.
+    /// Returns the item id from a raw key without allocating.
     ///
-    /// Panics in debug builds if the provided slice does not start with the
-    /// expected `available/` prefix.
+    /// With tightened encodings, the key is the id itself.
     pub fn id_suffix_from_key_bytes(main_key_bytes: &[u8]) -> &[u8] {
-        debug_assert!(main_key_bytes.starts_with(Self::PREFIX));
-        &main_key_bytes[Self::PREFIX.len()..]
+        main_key_bytes
     }
 }
 
@@ -69,13 +62,8 @@ impl AsRef<[u8]> for AvailableKey {
 }
 
 impl InProgressKey {
-    pub const PREFIX: &'static [u8] = b"in_progress/";
-
     pub fn from_id(id: &[u8]) -> Self {
-        let mut key = Vec::with_capacity(Self::PREFIX.len() + id.len());
-        key.extend_from_slice(Self::PREFIX);
-        key.extend_from_slice(id);
-        Self(key)
+        Self(id.to_vec())
     }
 
     pub fn as_bytes(&self) -> &[u8] {
@@ -90,14 +78,11 @@ impl AsRef<[u8]> for InProgressKey {
 }
 
 impl VisibilityIndexKey {
-    pub const PREFIX: &'static [u8] = b"visibility_index/";
-
     /// Build a visibility index key from a visible-at timestamp (secs since epoch) and id.
     /// Timestamp is encoded as big-endian to preserve lexicographic ordering.
     pub fn from_visible_ts_and_id(visible_ts_secs: u64, id: &[u8]) -> Self {
         let ts_be = visible_ts_secs.to_be_bytes();
-        let mut key = Vec::with_capacity(Self::PREFIX.len() + ts_be.len() + 1 + id.len());
-        key.extend_from_slice(Self::PREFIX);
+        let mut key = Vec::with_capacity(ts_be.len() + 1 + id.len());
         key.extend_from_slice(&ts_be);
         key.extend_from_slice(b"/");
         key.extend_from_slice(id);
@@ -110,13 +95,7 @@ impl VisibilityIndexKey {
 
     /// Parse the visible-at timestamp (secs since epoch) from a visibility index key.
     pub fn parse_visible_ts_secs(idx_key: &[u8]) -> Result<u64> {
-        debug_assert_eq!(
-            &idx_key[..VisibilityIndexKey::PREFIX.len()],
-            VisibilityIndexKey::PREFIX
-        );
-
-        let ts_start = Self::PREFIX.len();
-        let ts_end = ts_start + 8;
+        let ts_end = 8;
         if idx_key.len() < ts_end + 1 {
             return Err(Error::AssertionFailed {
                 msg: format!("malformed key: {:?}", idx_key),
@@ -124,14 +103,14 @@ impl VisibilityIndexKey {
             });
         }
         let mut ts_be = [0u8; 8];
-        ts_be.copy_from_slice(&idx_key[ts_start..ts_end]);
+        ts_be.copy_from_slice(&idx_key[..ts_end]);
         Ok(u64::from_be_bytes(ts_be))
     }
 
     /// Split a visibility index key into (timestamp_secs, id_slice).
     pub fn split_ts_and_id(idx_key: &[u8]) -> Result<(u64, &[u8])> {
         let ts = Self::parse_visible_ts_secs(idx_key)?;
-        let id_start = Self::PREFIX.len() + 8 + 1; // prefix + ts + '/'
+        let id_start = 8 + 1; // ts + '/'
         if id_start > idx_key.len() {
             return Err(Error::AssertionFailed {
                 msg: format!("malformed key: {:?}", idx_key),
@@ -149,13 +128,8 @@ impl AsRef<[u8]> for VisibilityIndexKey {
 }
 
 impl LeaseKey {
-    pub const PREFIX: &'static [u8] = b"leases/";
-
     pub fn from_lease_bytes(lease: &[u8]) -> Self {
-        let mut key = Vec::with_capacity(Self::PREFIX.len() + lease.len());
-        key.extend_from_slice(Self::PREFIX);
-        key.extend_from_slice(lease);
-        Self(key)
+        Self(lease.to_vec())
     }
 
     pub fn as_bytes(&self) -> &[u8] {
@@ -170,12 +144,9 @@ impl AsRef<[u8]> for LeaseKey {
 }
 
 impl LeaseExpiryIndexKey {
-    pub const PREFIX: &'static [u8] = b"lease_expiry/";
-
     pub fn from_expiry_ts_and_lease(expiry_ts_secs: u64, lease: &[u8]) -> Self {
         let ts_be = expiry_ts_secs.to_be_bytes();
-        let mut key = Vec::with_capacity(Self::PREFIX.len() + ts_be.len() + 1 + lease.len());
-        key.extend_from_slice(Self::PREFIX);
+        let mut key = Vec::with_capacity(ts_be.len() + 1 + lease.len());
         key.extend_from_slice(&ts_be);
         key.extend_from_slice(b"/");
         key.extend_from_slice(lease);
@@ -187,8 +158,7 @@ impl LeaseExpiryIndexKey {
     }
 
     pub fn parse_expiry_ts_secs(idx_key: &[u8]) -> Result<u64> {
-        let ts_start = Self::PREFIX.len();
-        let ts_end = ts_start + 8;
+        let ts_end = 8;
         if idx_key.len() < ts_end + 1 {
             return Err(Error::assertion_failed(&format!(
                 "malformed key: {:?}",
@@ -196,18 +166,13 @@ impl LeaseExpiryIndexKey {
             )));
         }
         let mut ts_be = [0u8; 8];
-        ts_be.copy_from_slice(&idx_key[ts_start..ts_end]);
+        ts_be.copy_from_slice(&idx_key[..ts_end]);
         Ok(u64::from_be_bytes(ts_be))
     }
 
     pub fn split_ts_and_lease(idx_key: &[u8]) -> Result<(u64, &[u8])> {
-        debug_assert_eq!(
-            &idx_key[..LeaseExpiryIndexKey::PREFIX.len()],
-            LeaseExpiryIndexKey::PREFIX
-        );
-
         let ts = Self::parse_expiry_ts_secs(idx_key)?;
-        let lease_start = Self::PREFIX.len() + 8 + 1; // prefix + ts + '/'
+        let lease_start = 8 + 1; // ts + '/'
         if lease_start > idx_key.len() {
             return Err(Error::assertion_failed(&format!(
                 "malformed key: {:?}",

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,9 +1,8 @@
 use capnp::message::{self, TypedReader};
 use capnp::serialize;
 use rocksdb::{
-    ColumnFamilyDescriptor, Direction, IteratorMode, OptimisticTransactionDB,
-    OptimisticTransactionOptions, Options, ReadOptions, SliceTransform, WriteBatchWithTransaction,
-    WriteOptions,
+    ColumnFamilyDescriptor, IteratorMode, OptimisticTransactionDB, OptimisticTransactionOptions,
+    Options, ReadOptions, SliceTransform, WriteBatchWithTransaction, WriteOptions,
 };
 use std::path::Path;
 use uuid::Uuid;
@@ -239,11 +238,11 @@ impl Storage {
 
     /// Return the next visibility timestamp (secs since epoch) among items in the
     /// visibility index, if any. This is determined by reading the first key in
-    /// the `visibility_index/` namespace which is ordered by big-endian timestamp.
+    /// the `visibility_index` CF which is ordered by big-endian timestamp.
     pub fn peek_next_visibility_ts_secs(&self) -> Result<Option<u64>> {
         let mut iter = self
             .db
-            .prefix_iterator_cf(self.cf_visibility_index(), VisibilityIndexKey::PREFIX);
+            .iterator_cf(self.cf_visibility_index(), IteratorMode::Start);
         if let Some(kv) = iter.next() {
             let (idx_key, _) = kv?;
             Ok(Some(VisibilityIndexKey::parse_visible_ts_secs(&idx_key)?))
@@ -286,17 +285,15 @@ impl Storage {
         let snapshot = txn.snapshot();
         let mut ro_iter = ReadOptions::default();
         ro_iter.set_snapshot(&snapshot);
-        ro_iter.set_prefix_same_as_start(true);
         // Upper bound: include all visibility_index entries with timestamp <= now_secs
         // by setting an exclusive upper bound at (now_secs + 1).
-        let mut viz_upper_bound: Vec<u8> = Vec::with_capacity(VisibilityIndexKey::PREFIX.len() + 8);
-        viz_upper_bound.extend_from_slice(VisibilityIndexKey::PREFIX);
+        let mut viz_upper_bound: Vec<u8> = Vec::with_capacity(8);
         viz_upper_bound.extend_from_slice(&(now_secs.saturating_add(1)).to_be_bytes());
         ro_iter.set_iterate_upper_bound(viz_upper_bound.clone());
         let mut ro_get = ReadOptions::default();
         ro_get.set_snapshot(&snapshot);
         // Prefix-bounded forward iterator from the prefix start using the snapshot-bound ReadOptions
-        let mode = IteratorMode::From(VisibilityIndexKey::PREFIX, Direction::Forward);
+        let mode = IteratorMode::Start;
         let viz_iter = txn.iterator_cf_opt(self.cf_visibility_index(), ro_iter, mode);
 
         let mut polled_items = Vec::with_capacity(n);
@@ -523,23 +520,15 @@ impl Storage {
         // Restrict iterator to only keys with expiry_ts <= now by setting an
         // exclusive upper bound at (now + 1).
         let mut ro = ReadOptions::default();
-        ro.set_prefix_same_as_start(true);
-        let mut expiry_upper_bound: Vec<u8> =
-            Vec::with_capacity(LeaseExpiryIndexKey::PREFIX.len() + 8);
-        expiry_upper_bound.extend_from_slice(LeaseExpiryIndexKey::PREFIX);
+        let mut expiry_upper_bound: Vec<u8> = Vec::with_capacity(8);
         expiry_upper_bound.extend_from_slice(&(now_secs.saturating_add(1)).to_be_bytes());
         ro.set_iterate_upper_bound(expiry_upper_bound.clone());
-        let mode = IteratorMode::From(LeaseExpiryIndexKey::PREFIX, Direction::Forward);
+        let mode = IteratorMode::Start;
         let iter = txn.iterator_cf_opt(self.cf_lease_expiry(), ro, mode);
         // Avoid deleting keys while iterating; collect expiry index keys to delete later.
         let mut expiry_index_keys_to_delete: Vec<Vec<u8>> = Vec::new();
         for kv in iter {
             let (idx_key, _) = kv?;
-
-            debug_assert_eq!(
-                &idx_key[..LeaseExpiryIndexKey::PREFIX.len()],
-                LeaseExpiryIndexKey::PREFIX
-            );
 
             let _idx_val = txn
                 .get_pinned_for_update_cf(self.cf_lease_expiry(), &idx_key, true)?
@@ -1468,12 +1457,8 @@ mod tests {
         let mut before = 0usize;
         {
             let txn = storage.db.transaction();
-            let mut ro = rocksdb::ReadOptions::default();
-            ro.set_prefix_same_as_start(true);
-            let mode = rocksdb::IteratorMode::From(
-                LeaseExpiryIndexKey::PREFIX,
-                rocksdb::Direction::Forward,
-            );
+            let ro = rocksdb::ReadOptions::default();
+            let mode = rocksdb::IteratorMode::Start;
             let iter = txn.iterator_cf_opt(storage.cf_lease_expiry(), ro, mode);
             for kv in iter {
                 let (idx_key, _val) = kv?;
@@ -1492,12 +1477,8 @@ mod tests {
         let mut after = 0usize;
         {
             let txn = storage.db.transaction();
-            let mut ro = rocksdb::ReadOptions::default();
-            ro.set_prefix_same_as_start(true);
-            let mode = rocksdb::IteratorMode::From(
-                LeaseExpiryIndexKey::PREFIX,
-                rocksdb::Direction::Forward,
-            );
+            let ro = rocksdb::ReadOptions::default();
+            let mode = rocksdb::IteratorMode::Start;
             let iter = txn.iterator_cf_opt(storage.cf_lease_expiry(), ro, mode);
             for kv in iter {
                 let (idx_key, _val) = kv?;
@@ -1567,10 +1548,8 @@ mod tests {
         // Count expiry index entries that reference this lease
         let mut count = 0usize;
         let txn = storage.db.transaction();
-        let mut ro = rocksdb::ReadOptions::default();
-        ro.set_prefix_same_as_start(true);
-        let mode =
-            rocksdb::IteratorMode::From(LeaseExpiryIndexKey::PREFIX, rocksdb::Direction::Forward);
+        let ro = rocksdb::ReadOptions::default();
+        let mode = rocksdb::IteratorMode::Start;
         let iter = txn.iterator_cf_opt(
             storage
                 .db
@@ -1909,8 +1888,7 @@ mod tests {
         // Iterate visibility index and capture the first entry
         let mut ro = rocksdb::ReadOptions::default();
         ro.set_prefix_same_as_start(true);
-        let mode =
-            rocksdb::IteratorMode::From(VisibilityIndexKey::PREFIX, rocksdb::Direction::Forward);
+        let mode = rocksdb::IteratorMode::Start;
         let mut viz_iter = txn.iterator_cf_opt(
             storage
                 .db


### PR DESCRIPTION
Remove textual prefixes from database keys to shorten them and simplify iteration logic within their respective Column Families.

---
<a href="https://cursor.com/background-agent?bcId=bc-d450c29b-379f-4179-a85f-0a349d37c1d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d450c29b-379f-4179-a85f-0a349d37c1d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

