### PR TITLE
Implement optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1468,6 +1468,7 @@ dependencies = [
  "rand 0.8.5",
  "rocksdb",
  "scopeguard",
+ "smallvec",
  "socket2 0.5.10",
  "tempfile",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ console-subscriber = "0.4"
 uuid = { version = "1.18.0", features = ["std", "v4", "v7", "zerocopy"] }
 rand = "0.8"
 socket2 = "0.5"
+smallvec = { version = "1.13" }
 
 [build-dependencies]
 capnpc = "0.21.2"


### PR DESCRIPTION
Optimize `build_lease_entry_message` to reduce heap allocations and skip unnecessary sorting for small batches of IDs.

The `build_lease_entry_message` function previously used a `Vec` for collecting ID slices and always performed a sort. This PR introduces `SmallVec` to use a stack-allocated buffer for up to 32 IDs, avoiding heap allocations for common small batches. It also adds a check to skip the sorting step if there are 0 or 1 IDs, which is an unnecessary operation, thereby improving performance by reducing memory overhead and CPU cycles.

---
<a href="https://cursor.com/background-agent?bcId=bc-7fad3732-5c9d-4af2-b8eb-f0d7fdabafc5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7fad3732-5c9d-4af2-b8eb-f0d7fdabafc5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>