### PR TITLE
Simplify fair distribution algorithm

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -37,6 +37,25 @@ impl Server {
             coalescer,
         }
     }
+
+    /// Build a server with a custom coalescing window (ms) for polling.
+    pub fn new_with_coalescing_window_ms(
+        storage: Arc<RetriedStorage<Storage>>,
+        notify: Arc<Notify>,
+        shutdown_tx: watch::Sender<bool>,
+        batch_window_ms: u64,
+    ) -> Self {
+        let coalescer = Arc::new(PollCoalescer::with_batch_window_ms(
+            Arc::clone(&storage),
+            batch_window_ms,
+        ));
+        Self {
+            storage,
+            notify,
+            shutdown_tx,
+            coalescer,
+        }
+    }
 }
 
 const BACKGROUND_LEASE_EXPIRY_INTERVAL_SECS: u64 = 1;

--- a/tests/server_poll.rs
+++ b/tests/server_poll.rs
@@ -468,8 +468,7 @@ async fn coalesced_polls_round_robin_fairness_unequal_demands() {
         // Round-robin fairness should distribute the 6 items as counts {3,2,1} (in some order).
         let quotas = [5u32, 3u32, 1u32];
         let mut handles = Vec::new();
-        for idx in 0..quotas.len() {
-            let q = quotas[idx];
+        for (idx, &q) in quotas.iter().enumerate() {
             let client = queue_client.clone();
             handles.push(tokio::task::spawn_local(async move {
                 let mut poll = client.poll_request();


### PR DESCRIPTION
Simplify item distribution logic in `PollCoalescer` using a round-robin queue for fair allocation.

---
<a href="https://cursor.com/background-agent?bcId=bc-76ef61d7-30c0-4338-8f85-c55d978754e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-76ef61d7-30c0-4338-8f85-c55d978754e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

