### PR TITLE
Add request coalescer config to cli flags

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -12,6 +12,7 @@ use crate::protocol::queue::{
 use crate::storage::{RetriedStorage, Storage};
 mod coalescer;
 use coalescer::PollCoalescer;
+pub use coalescer::PollCoalescingConfig;
 
 // https://github.com/capnproto/capnproto-rust/tree/master/capnp-rpc
 // https://github.com/capnproto/capnproto-rust/blob/master/capnp-rpc/examples/hello-world/server.rs
@@ -30,6 +31,21 @@ impl Server {
         shutdown_tx: watch::Sender<bool>,
     ) -> Self {
         let coalescer = Arc::new(PollCoalescer::new(Arc::clone(&storage)));
+        Self {
+            storage,
+            notify,
+            shutdown_tx,
+            coalescer,
+        }
+    }
+
+    pub fn new_with_coalescer_config(
+        storage: Arc<RetriedStorage<Storage>>,
+        notify: Arc<Notify>,
+        shutdown_tx: watch::Sender<bool>,
+        cfg: PollCoalescingConfig,
+    ) -> Self {
+        let coalescer = Arc::new(PollCoalescer::with_config(Arc::clone(&storage), cfg));
         Self {
             storage,
             notify,


### PR DESCRIPTION
Add CLI flags to configure the request coalescer behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-799dd977-500d-454e-8440-cc1d8eb96843">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-799dd977-500d-454e-8440-cc1d8eb96843">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

